### PR TITLE
provide a validator option

### DIFF
--- a/bootstrap-tagmanager.js
+++ b/bootstrap-tagmanager.js
@@ -176,6 +176,11 @@
          tag = tag.charAt(0).toUpperCase() + tag.slice(1).toLowerCase();
       }
 
+      // call the validator (if any) and do not let the tag pass if invalid
+      if (tagManagerOptions.validator !== undefined) {
+        if ( tagManagerOptions.validator(tag) !== true ) return;
+      }
+
       var obj;
       if (robj == null)
          obj = jQuery(this);


### PR DESCRIPTION
to see if the tag is to your likings, usefull for e-mail addresses:

```
$('x').tagManager({
  validator: function(tag) {
    var isEmail_re       = /^\s*[\w\-\+_]+(\.[\w\-\+_]+)*\@[\w\-\+_]+\.[\w\-\+_]+(\.[\w\-\+_]+)*\s*$/;
   return String(tag).search (isEmail_re) != -1;
}
```

only when the validator returns `true` the tag is accepted (any other true-ish value will be disregarded)

(PS: Great work! Keep it up!)
(PS-II: Another pull-request is already in the making ;)
