### PR TITLE
Support for multiple tagmanager controls in a page.

### DIFF
--- a/bootstrap-tagmanager.js
+++ b/bootstrap-tagmanager.js
@@ -19,7 +19,8 @@
          maxTags: 0,
          hiddenTagListName: null,
          deleteTagsOnBackspace: false,
-         tagsContainer: null
+         tagsContainer: null,
+         tagCloseIcon:'x'
       };
 
       $.extend(tagManagerOptions, options);
@@ -176,7 +177,7 @@
             var newTagId = objName+'_'+tagId;
             var newTagRemoveId = objName+'_Remover_'+ tagId;
             var html = '';
-            html += '<span class="myTag" id="'+newTagId+ '"><span>' + tag + '&nbsp;&nbsp;</span><a href="#" class="myTagRemover" id="'+newTagRemoveId+'" TagIdToRemove="'+tagId+'" title="Remove">x</a></span>';
+            html += '<span class="myTag" id="'+newTagId+ '"><span>' + tag + '&nbsp;&nbsp;</span><a href="#" class="myTagRemover" id="'+newTagRemoveId+'" TagIdToRemove="'+tagId+'" title="Remove">'+tagManagerOptions.tagCloseIcon+'</a></span>';
         
             if(tagManagerOptions.tagsContainer != null)
             {


### PR DESCRIPTION
The tagmanager creates tags with a hard-coded prefix, and maintains state at a plugin level instead of the control level. This makes it unusable if you need more than one in a single page. The commits in this pull request remove the global state, creates tags with prefix based on inputs name and adds support to put tags in a custom container.

Please review and merge.
