### PR TITLE
add delegation of tag list pop-up to bootstrap's typeahead

### DIFF
--- a/bootstrap-tagmanager.js
+++ b/bootstrap-tagmanager.js
@@ -82,6 +82,8 @@
             }else if(tagManagerOptions.typeaheadAjaxPolling){
                obj.typeahead({source: ajaxPolling});
             }
+         } else if (tagManagerOptions.typeaheadDelegate) {
+             obj.typeahead(tagManagerOptions.typeaheadDelegate)
          }
       };
 


### PR DESCRIPTION
This patch exposes all of bootstrap's typeahead behaviour to tagmanager.

To use, add the `typeaheadDelegate` option to tagmanager's list of options and pass in a json object with your required typeahead parameters.

For example:

``` javascript
typeahead: true,
typeaheadDelegate: {
  source: function(query, process) {
    $.get('/tags', { query: query, limit: 10 }, function(data) {
      return process(data)
    })
  },
  items: 10,
  minLength: 2
}
```

This makes the ajax call only after at least 2 characters have been typed. The typed characters are passed with the call (in `query`).

@max-favilli: This also fixed #11
