### PR TITLE
sanitize objName for ID usage

### DIFF
--- a/bootstrap-tagmanager.js
+++ b/bootstrap-tagmanager.js
@@ -49,7 +49,7 @@
       }
       
       var obj = this;
-      var objName = obj.attr('name');
+      var objName = obj.attr('name').replace(/[^\w]/g, '_');
       var lastTagId = 0;
       var queuedTag = "";
       var delimeters = tagManagerOptions.delimeters;


### PR DESCRIPTION
This patch plays nice with names that contain brackets and other not compatible with ID symbols. Rails generate input name fields like 'video[tag_list]'.
