### PR TITLE
added tagClass to options

### DIFF
--- a/bootstrap-tagmanager.js
+++ b/bootstrap-tagmanager.js
@@ -39,7 +39,8 @@
       hiddenTagListName: null,
       deleteTagsOnBackspace: true,
       tagsContainer: null,
-      tagCloseIcon: 'x'
+      tagCloseIcon: 'x',
+      tagClass: ''
     };
 
     jQuery.extend(tagManagerOptions, options);
@@ -252,7 +253,8 @@
         var newTagId = objName + '_' + tagId;
         var newTagRemoveId = objName + '_Remover_' + tagId;
         var html = '';
-        html += '<span class="myTag" id="' + newTagId + '"><span>' + tag + '&nbsp;&nbsp;</span><a href="#" class="myTagRemover" id="' + newTagRemoveId + '" TagIdToRemove="' + tagId + '" title="Remove">' + tagManagerOptions.tagCloseIcon + '</a></span>';
+        var cl = tagManagerOptions.tagClass ? ' '+tagManagerOptions.tagClass : '';
+        html += '<span class="myTag'+cl+'" id="' + newTagId + '"><span>' + tag + '&nbsp;&nbsp;</span><a href="#" class="myTagRemover" id="' + newTagRemoveId + '" TagIdToRemove="' + tagId + '" title="Remove">' + tagManagerOptions.tagCloseIcon + '</a></span> ';
 
         if (tagManagerOptions.tagsContainer != null) {
           jQuery(tagManagerOptions.tagsContainer).append(html)


### PR DESCRIPTION
with this new option we can add a class to the tags themselves when they get added to the container or before the input element. This would make it so we dont need to include the default css that came with tag manager, along with allowing us to use predefined css rules to the tags.
In my case, I can now do the following with this addition..

``` javascript
$('.tags').tagsManager({
  tagClass: 'label label-inverse'
})
```

and the newly added tags will have the label classes applied to it.
