### PR TITLE
Ignoring character case when checking if the new tag is already on the list.

### DIFF
--- a/bootstrap-tagmanager.js
+++ b/bootstrap-tagmanager.js
@@ -222,7 +222,7 @@
 
       var alreadyInList = false;
       var tlisLowerCase = tlis.map(function(elem) { return elem.toLowerCase(); }); 
-      var p = jQuery.inArray(tag, tlisLowerCase);
+      var p = jQuery.inArray(tag.toLowerCase(), tlisLowerCase);
       if (-1 != p) {
         // console.log("tag:" + tag + " !!already in list!!");
         alreadyInList = true;


### PR DESCRIPTION
I think that creating unique tags is useful. When doing that checking uniqueness while ignoring character case makes sense. So I am processing the list of tags into a separate variable. The tags on the list in that new variable `tlisLowerCase` are all in lowercase. That variable is used only for checking if the new tag is already on the list.
