### PR TITLE
typing fast sometimes missed the delimiters

### DIFF
--- a/bootstrap-tagmanager.js
+++ b/bootstrap-tagmanager.js
@@ -337,7 +337,7 @@
         // console.log("keyup: " + e.keyCode);
       });
 
-      obj.on("keyup", obj, function (e) {
+      obj.on("keydown", obj, function (e) {
         var p = jQuery.inArray(e.which, delimeters);
         if (-1 != p) {
           //user just entered a valid delimeter
@@ -348,10 +348,7 @@
         }
 
         // console.log("keyup: " + e.which);
-      });
-
-      if (tagManagerOptions.deleteTagsOnBackspace) {
-        obj.on("keydown", obj, function (e) {
+        if (tagManagerOptions.deleteTagsOnBackspace) {
           var p = jQuery.inArray(e.which, backspace);
           if (-1 != p) {
             //user just entered backspace or equivalent
@@ -363,8 +360,8 @@
               popTag();
             }
           }
-        });
-      }
+        }
+      });
 
       obj.change(function (e) {
         e.cancelBubble = true;


### PR DESCRIPTION
I noticed that if I was typing kinda fast that in the input box that it was skipping the delimiters that were set, and adding the tag a little late.. 
for example.. try typing hello,world fast, the tag would then show up as `hello,w` keeping the delimiter within the tag. to fix this I removed the `keyup` reference and made it `keydown` and then also combined the `tagManagerOptions.deleteTagsOnBackspace` within the function since it was listening to `keydown` anyways
I also think we could combine the `keypress` trigger but I didnt test that one out
