### PR TITLE
add an option to let user use tab as enter

### DIFF
--- a/bootstrap-tagmanager.js
+++ b/bootstrap-tagmanager.js
@@ -28,6 +28,7 @@
       prefilled: null,
       CapitalizeFirstLetter: false,
       preventSubmitOnEnter: true,
+      preventNavigationOnTab: true,
       typeahead: false,
       typeaheadAjaxSource: null,
       typeaheadAjaxPolling: false,
@@ -365,7 +366,14 @@
           }
         });
       }
-
+      if (tagManagerOptions.preventNavigationOnTab){
+        obj.on("keydown", obj, function(e){
+            if (e.which == 9 && obj.val()){
+              obj.trigger('blur');
+              e.preventDefault();
+            }
+        });
+      }
       obj.change(function (e) {
         e.cancelBubble = true;
         e.returnValue = false;


### PR DESCRIPTION
By default, the tab navigates the focus to the next input, which is not many of us want. 
If we want to use the Tab key as "confirm a tag input" like the Enter key does, we can turn on the preventNavigationOnTab to do so in this pull-request. The Tab key will still navigate if the input is empty. This behavior is commonly used in modern websites and software like facebook and chrome.
