### PR TITLE
Adding tags:refresh custom event on list refresh

### DIFF
--- a/bootstrap-tagmanager.js
+++ b/bootstrap-tagmanager.js
@@ -237,6 +237,7 @@
       if (lhiddenTagList == undefined)
         return;
 
+      obj.trigger('tags:refresh', tlis.join(","));
       jQuery(lhiddenTagList).val(tlis.join(",")).change();
     };
 
@@ -281,7 +282,7 @@
       if (tagManagerOptions.maxTags > 0 && tlis.length >= tagManagerOptions.maxTags) return;
 
       var alreadyInList = false;
-      var tlisLowerCase = tlis.map(function(elem) { return elem.toLowerCase(); }); 
+      var tlisLowerCase = tlis.map(function(elem) { return elem.toLowerCase(); });
       var p = jQuery.inArray(tag.toLowerCase(), tlisLowerCase);
       if (-1 != p) {
         // console.log("tag:" + tag + " !!already in list!!");
@@ -466,7 +467,7 @@
 
         // check the typeahead list selection
         var data = $(this).data('typeahead');
-        if (data) { 
+        if (data) {
           isSelectedFromList = $(this).data('typeahead').$menu.find("*")
             .filter(listItemSelector)
             .hasClass(selectedItemClass);


### PR DESCRIPTION
Calling a custom event tags:refresh when the list is refreshed. Users can bind to the event and use the data to update external copies of the tag list
