### PR TITLE
Prevent double-initialization of TagManager

### DIFF
--- a/bootstrap-tagmanager.js
+++ b/bootstrap-tagmanager.js
@@ -372,6 +372,10 @@
         return;
       }
       
+      // prevent double-initialization of TagManager
+      if ($(this).data('tagManager')){ return false; }
+      $(this).data('tagManager', true);
+
       //let's store some instance specific data directly into the DOM object
       var tlis = new Array();
       var tlid = new Array();


### PR DESCRIPTION
If you call $().tagManager() more than once on the same object, it will double-initialize and cause strange behavior like duplicated tags, deleting multiple tags on each backspace, etc. I've added a feature that prevents this, but still allows you to run the pop/push commands as normal.

In some apps where Javascript is used heavily, it may be hard to avoid double-calling tagManager(), and moreover, this pattern is used by many of the best jQuery plugins. See: http://stackoverflow.com/questions/11066214/stop-jquery-plugin-applying-twice-to-same-element
