### PR TITLE
Added support for typeahead's "updater" callback

### DIFF
--- a/bootstrap-tagmanager.js
+++ b/bootstrap-tagmanager.js
@@ -528,8 +528,7 @@
               pushTag(user_input, null, true);
               queuedTag = user_input;
               // console.log('Handler for .change() called, typeahead value pushed:' + queuedTag);
-            }
-            
+            }            
             isSelectedFromList = false;
             $(this).data('typeahead').$menu.find(listItemSelector).removeClass(selectedItemClass);
           }
@@ -604,4 +603,3 @@
 
   }
 })(jQuery);
-


### PR DESCRIPTION
Bootstrap typeahead supports the "updater", a handy callback for post-processing selected elements. I've added support for this, but only for the standard source typeahead, not the ajax-based
