### PR TITLE
Added support for setting prefilled with a function

### DIFF
--- a/bootstrap-tagmanager.js
+++ b/bootstrap-tagmanager.js
@@ -580,6 +580,7 @@
       if (tagManagerOptions.prefilled != null) {
         if (typeof (tagManagerOptions.prefilled) == "object") {
           var pta = tagManagerOptions.prefilled;
+
           jQuery.each(pta, function (key, val) {
             var a = 1;
             pushTag(val, obj, true);
@@ -591,7 +592,13 @@
             var a = 1;
             pushTag(val, obj, true);
           });
+        } else if (typeof (tagManagerOptions.prefilled) == "function") {
+          var pta = tagManagerOptions.prefilled().split(',');
 
+          jQuery.each(pta, function (key, val) {
+            var a = 1;
+            pushTag(val, obj, true);
+          });
         }
       }
     });


### PR DESCRIPTION
I needed a way to fill the tags using a function, so I added it:

``` javascript
    $(".tagManager").tagsManager({
        prefilled: function(){
            tags = $(".tagManager").val()
            $(".tagManager").val('')

            return tags
        },
        preventSubmitOnEnter: true,
        typeahead: true,
        typeaheadAjaxSource: '/tag/index/format/json',
        typeaheadAjaxPolling: true,
    })
```

Hope it's useful :)
