### PR TITLE
Fix the bug of remove icon can't work sometimes

### DIFF
--- a/bootstrap-tagmanager.js
+++ b/bootstrap-tagmanager.js
@@ -317,17 +317,16 @@
 
         var newTagId = objName + '_' + tagId;
         var newTagRemoveId = objName + '_Remover_' + tagId;
-        var html = '';
         var cl = tagManagerOptions.tagClass ? ' '+tagManagerOptions.tagClass : '';
-        html += '<span class="myTag'+cl+'" id="' + newTagId + '"><span>' + tag + '&nbsp;&nbsp;</span><a href="#" class="myTagRemover" id="' + newTagRemoveId + '" TagIdToRemove="' + tagId + '" title="Remove">' + tagManagerOptions.tagCloseIcon + '</a></span> ';
+        var $el = jQuery('<span class="myTag'+cl+'" id="' + newTagId + '"><span>' + tag + '&nbsp;&nbsp;</span><a href="#" class="myTagRemover" id="' + newTagRemoveId + '" TagIdToRemove="' + tagId + '" title="Remove">' + tagManagerOptions.tagCloseIcon + '</a></span> ');
 
         if (tagManagerOptions.tagsContainer != null) {
-            jQuery(tagManagerOptions.tagsContainer).append(html);
+            jQuery(tagManagerOptions.tagsContainer).append($el);
         } else {
-          obj.before(html);
+          obj.before($el);
         }
 
-        jQuery("#" + newTagRemoveId).on("click", obj, function (e) {
+        $el.find("#" + newTagRemoveId).on("click", obj, function (e) {
           e.preventDefault();
           var TagIdToRemove = parseInt(jQuery(this).attr("TagIdToRemove"));
           spliceTag(TagIdToRemove, e.data);


### PR DESCRIPTION
If the tag manager component is initialized before append to the dom
tree,
the remove icon won't work because of the selector (jQuery("#" +
newTagRemoveId") return empty.
