### PR TITLE
Fixed onlyTagList when use with typeaheadAjaxSource

### DIFF
--- a/bootstrap-tagmanager.js
+++ b/bootstrap-tagmanager.js
@@ -168,6 +168,7 @@
     var setTypeaheadSource = function (source) {
       obj.data('active', true);
       obj.data('typeahead').source = source;
+      tagManagerOptions.typeaheadSource = source;
       obj.data('active', false);
     };
 


### PR DESCRIPTION
I just added 

``` javascript
tagManagerOptions.typeaheadSource = source;
```

in 

``` javascript
var setTypeaheadSource = function (source) {
      obj.data('active', true);
      obj.data('typeahead').source = source;
      tagManagerOptions.typeaheadSource = source;
      obj.data('active', false);
   };
```
