### PR TITLE
Escape tags for display instead of emitting it as raw HTML

### DIFF
--- a/bootstrap-tagmanager.js
+++ b/bootstrap-tagmanager.js
@@ -349,9 +349,10 @@
 
         var newTagId = objName + '_' + tagId;
         var newTagRemoveId = objName + '_Remover_' + tagId;
+        var escaped = $("<span></span>").text(tag).html();
 
         var html = '<span class="' + tagClasses() + '" id="' + newTagId + '">';
-        html += '<span>' + tag + '</span>';
+        html += '<span>' + escaped + '</span>';
         html += '<a href="#" class="tm-tag-remove" id="' + newTagRemoveId + '" TagIdToRemove="' + tagId + '">';
         html += tagManagerOptions.tagCloseIcon + '</a></span> ';
         var $el = $(html);


### PR DESCRIPTION
As the user should not be able to enter <textarea> to break things badly. This is a quick and dirty implementation that uses the jQuery's .text() and .html() methods for escaping.
