### PR TITLE
Update bootstrap-tagmanager.js

### DIFF
--- a/bootstrap-tagmanager.js
+++ b/bootstrap-tagmanager.js
@@ -186,7 +186,7 @@
       if (typeof (tagManagerOptions.typeaheadAjaxSource) == "string") {
         $.ajax({
           cache: false,
-          type: "POST",
+          type: tagManagerOptions.typeaheadAjaxMethod,
           contentType: "application/json",
           dataType: "json",
           url: tagManagerOptions.typeaheadAjaxSource,


### PR DESCRIPTION
Setting the ajax method type to GET had no effect.  Was being set to POST inside ajaxpolling method.  Updated to take in the value from the options override
