### PR TITLE
Added readOnly option

### DIFF
--- a/tagmanager.js
+++ b/tagmanager.js
@@ -423,11 +423,8 @@
                 });
 
                 if (opts.readOnly) {
-                    $self.attr('readonly', true);
-                    opts.backspace = [];//clear out the ability to delete on backspace
-                } else {
-                    $self.attr('readonly', false);
-                }
+                    $self.attr('style', 'display: none');
+                } 
 
                 if (opts.prefilled !== null) {
                     if (typeof (opts.prefilled) === "object") {


### PR DESCRIPTION
This will make the input box readonly, and remove the tagCloseIcon from being rendered.

Fairly simple - I might be missing something. Wasn't sure if I should .attr('readonly', true) the field or disable the field. Readonly will still get posted, although I'm not sure why a tagManager's textbox would need to be posted back.
