### PR TITLE
Add bower support

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,31 @@
+{
+  "name": "tagmanager",
+  "main": [
+    "tagmanager.js",
+    "tagmanager.css",
+    "tagmanager.less"
+  ],
+  "authors": [
+    "Max Favilli"
+  ],
+  "description": "A jQuery plugin (working nicely with twitter bootstrap)",
+  "keywords": [
+    "tag",
+    "autocomplete",
+    "jquery",
+    "bootstrap",
+    "typeahead"
+  ],
+  "dependencies": {
+    "jquery": ">= 1.0.0"
+  },
+  "license": "MPL",
+  "homepage": "http://welldonethings.com/tags/manager/v3",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
This PR add bower support (as asked in #165).

You simply need to register your package on bower:

``` console
$ bower register tagmanager git://github.com/max-favilli/tagmanager.git
```

There is only one problem: someone already registered an outdated fork of your project and you will have to ask to unregister it before here: https://github.com/bower/bower/issues/120
