### PR TITLE
Return tag's jQuery element in tm:pushed trigger

### DIFF
--- a/tagmanager.js
+++ b/tagmanager.js
@@ -161,7 +161,7 @@
 
                 privateMethods.refreshHiddenTagList.call($self);
 
-                if (!ignoreEvents) { $self.trigger('tm:pushed', [tag, tagId]); }
+                if (!ignoreEvents) { $self.trigger('tm:pushed', [tag, tagId, $el]); }
 
                 privateMethods.showOrHide.call($self);
                 //if (tagManagerOptions.maxTags > 0 && tlis.length >= tagManagerOptions.maxTags) {


### PR DESCRIPTION
In some cases, when
you need to add elements to the  tag container or change properties
or make jQuery selections, you need an instance of jQuery tag's element

I propose to add that jQuery element ($el) as a new trigger argument
of tm:pushed event
