### PR TITLE
Make event "pushing" cancelable.

### DIFF
--- a/tagmanager.js
+++ b/tagmanager.js
@@ -119,7 +119,15 @@
 
                     tagId = ++max;
                 }
-                if (!ignoreEvents) { $self.trigger('tm:pushing', [tag, tagId]); }
+                if (!ignoreEvents) {
+                	var control={cancel:false,tag:tag,tagId: tagId};
+                	$self.trigger('tm:pushing', [control, tag, tagId]);
+                	if (control.cancel) {
+                		console.log("Pushing canceled");
+                		$self.val("");
+                		return;
+                	}
+                }
                 tlis.push(tag);
                 tlid.push(tagId);
 


### PR DESCRIPTION
Give user's ability to cancel event so stop pushing by setting cancel property to false.
Object control contain also tag and tagId.
Exemple of use :
$( ".tm-input" ).on( "tm:pushing", function( event,control ) {
  if (control.tag == "bad value") {
        control.cancel=true;
 }
});
