### PR TITLE
Replaced component-installer with composer-installers-extender.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,6 @@
         }
     },
     "require": {
-        "robloach/component-installer": "*"
+        "oomphinc/composer-installers-extender": "dev-master"
     }
 }


### PR DESCRIPTION
`component-installer` is deprecated as documented: https://github.com/RobLoach/component-installer

As the project suggest have to be replaced by https://github.com/oomphinc/composer-installers-extender