### PR TITLE
added tagmanager publicMethod 'extractTagsFromString'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.3-bmaso-extractTagsFromString
+* support for new public method "extractTagsFromString"
+
 ## 3.0.1 - 2013-12-12
 
 * Issue #180: Add 'tags' method to retrieve tags (LukeL99)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [Tags Manager v3.0.2](http://welldonethings.com/tags/manager/v3)
+# [Tags Manager v3.0.3-bmaso-extractTagsFromString](http://welldonethings.com/tags/manager/v3)
 
 A jQuery plugin to create tag input fields, which works nicely with [Twitter Typeahead.js](http://twitter.github.io/typeahead.js/) and [Twitter Bootstrap](http://twitter.github.com/bootstrap)
 

--- a/TagManager.jquery.json
+++ b/TagManager.jquery.json
@@ -1,6 +1,6 @@
 {
   "name": "TagManager",
-  "version": "3.0.2",
+  "version": "3.0.-extractTagsFromString",
   "title": "Tag Manager",
   "author": {
     "name": "Max Favilli",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A jQuery plugin to create tag input fields, which works nicely with Twitter Typeahead.js and Twitter Bootstrap",
     "type": "component",
     "homepage": "https://github.com/max-favilli/tagmanager",
-    "version": "3.0.1",
+    "version": "3.0.3-bmaso-extractTagsFromString",
     "license": "MPL",
     "authors": [
         {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "TagManager",
-  "version": "3.0.1",
+  "version": "3.0.3-bmaso-extractTagsFromString",
   "title": "Tag Manager",
   "author": {
     "name": "Max Favilli",

--- a/tagmanager.js
+++ b/tagmanager.js
@@ -1,5 +1,5 @@
 /* ===================================================
- * tagmanager.js v3.0.2
+ * tagmanager.js v3.0.3-bmaso-extractTagsFromString
  * http://welldonethings.com/tags/manager
  * ===================================================
  * Copyright 2012 Max Favilli
@@ -241,6 +241,26 @@
     tags: function () {
       var $self = this, tlis = $self.data("tlis");
       return tlis;
+    },
+
+    extractTagsFromString: function(sourceStr) {
+      var $self = $(this), opts = $self.data('opts'), str = $.trim(sourceStr);
+      for(var ii=0; ii<str.length; ii++) {
+        if($.inArray(str.charCodeAt(ii), opts.delimiterChars) != -1) {
+          str = str.substring(0, ii) + "#" + str.substring(ii+1, str.length);
+        }
+      }
+
+      var tagsArr = str.split(/[#\s]+/);
+
+      //...remove any 0-length members of the response array...
+      for(var jj=tagsArr.length-1; jj>=0; --jj) {
+        if(!tagsArr[jj].length) {
+          tagsArr.splice(jj, 1); // note: Array.prototype.splice is a mutator method, so this changes original array
+        }
+      }
+
+      return tagsArr;
     }
   },
 


### PR DESCRIPTION
- bmaso needed ability to parse multiple tags at once specifically when users "paste" text w/ multiple tags into tm-input
- Created new tagmanager public method `extractTagsFromString`: returns an array of the tags present in any given string as if text had been typed in one character at a time
  - splits input string on tag delimiters
  - trims whitespace of each tag
- External code can then use `extractTagsFromString` and `pushTag` methods in conjunction to push multiple tags at once, e.g. as part of a "paste" event handler:

```
$(".tm-input").on("paste", function(e) {
  setTimeout(function() {
    //...compute tags present in the pasted text...
    var text = $(".tm-input").val();
    tagsArr = $(".tm-input").tagsManager("extractTagsFromString", text);

    //...clear input element contents...
    $(".tm-input").val('');

    //...push tags...
    for(var ii=0; ii<tagsArr.length; ii++) {
      $(".tm-input").tagsManager("pushTag", tagsArr[ii]);
    }
  }, 0);
});
```
